### PR TITLE
docs(adr): migrate architectural rules to MADR ADRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,25 @@
 
 Flutter mobile boilerplate using layered clean architecture with MobX state management, Retrofit API layer (`packages/api`), shared design system (`packages/design_system`), and GetIt + Injectable dependency injection. Melos-managed monorepo.
 
+## Architectural decisions
+
+Rules below are summaries. Full context, alternatives considered, and rationale are in [`docs/adr/`](docs/adr/README.md). Read the ADR when you need *why*.
+
+- **Layered architecture, adjacent-only access** — UI → State → Store → DioService → API Provider; UI never reaches Dio or stores directly. [ADR-0001](docs/adr/0001-layered-architecture.md)
+- **State vs Store separation** — `*_state.dart` is per-screen with no API access; `*_store.dart` owns API and may be feature-scoped or `@singleton`. [ADR-0002](docs/adr/0002-state-vs-store-separation.md)
+- **No use-case → use-case dependencies** — UCs depend on services/stores/navigators only; shared logic becomes a service, not a peer UC. [ADR-0003](docs/adr/0003-no-use-case-to-use-case-dependencies.md)
+- **Use-case taxonomy + colocation** — 4 UC types (API / Navigation / Service Coordination / State Delegation); placement follows the consumer layer; promote on second consumer. [ADR-0004](docs/adr/0004-use-case-taxonomy-and-colocation.md)
+- **Flat feature tree** — features are peers under a domain grouping; no nested `features/` inside a feature. [ADR-0005](docs/adr/0005-flat-feature-tree.md)
+- **Feature-owned singletons** — every store lives under its owning feature's `mobx/`, regardless of `@singleton` vs `@injectable`; `lib/shared/` is deprecated. [ADR-0006](docs/adr/0006-feature-owned-singletons.md)
+- **DI scopes + constructor injection** — `@injectable`, `@singleton`, `@lazySingleton`; flavor bindings via `@dev`/`@prod`; never `getIt<>()` inside classes (one allowed seam: `Provider(create:)`). [ADR-0007](docs/adr/0007-di-scopes-and-constructor-injection.md)
+- **`AppNavigator` routing abstraction** — pages never use `context.router`; states inject `AppNavigator`. [ADR-0008](docs/adr/0008-appnavigator-routing-abstraction.md)
+- **Provider-based state access** — page roots create `Provider<MyPageState>`; descendants read via `context.read<T>()`; never pass state as widget params. [ADR-0009](docs/adr/0009-provider-based-state-access.md)
+- **`HookWidget` default** — `HookWidget` for any widget needing controllers/effects/local state; `StatelessWidget` for pure presentation; `StatefulWidget` only for hook-incompatible APIs. [ADR-0010](docs/adr/0010-hookwidget-default.md)
+- **Retrofit + freezed typed API layer** — `@RestApi()` providers in `packages/api`; `@freezed sealed` DTOs; `ListResponseDto<T>` for paginated lists; access only via `DioService`. [ADR-0011](docs/adr/0011-retrofit-typed-api-layer.md)
+- **Mandatory localization** — no inline UI strings; `LocaleKeys.x.tr()` only; add to `assets/translations/en-US.json` then `melos run translations`. [ADR-0012](docs/adr/0012-mandatory-localization.md)
+- **DS tokens only in `lib/`** — no raw colors, text styles, or shadow stacks; tokens live in `packages/design_system` with both light + dark values. [ADR-0013](docs/adr/0013-design-system-tokens-only.md)
+- **Melos workspace, two packages** — `packages/api` + `packages/design_system` as Dart workspace siblings; melos scripts drive codegen / lint / test. [ADR-0014](docs/adr/0014-melos-package-split.md)
+
 ## Commands
 
 ```bash
@@ -14,7 +33,8 @@ flutter run -t lib/main_dev.dart
 flutter run -t lib/main_prod.dart
 
 # Bootstrap workspace (deps + codegen, all packages)
-melos bootstrap
+melos run bootstrap     # runs `melos run deps && melos run generate`
+# Note: bare `melos bootstrap` (Melos built-in) only fetches deps.
 
 # Code generation (after changing MobX, Retrofit, Freezed, Injectable annotations)
 melos run build
@@ -41,7 +61,9 @@ melos run deploy-dev
 
 ## Architecture
 
-### Layer Rules (Non-Negotiable)
+Rationale + alternatives: [ADR-0001](docs/adr/0001-layered-architecture.md).
+
+### Layer Rules
 
 | Layer | Files | Can Access | Cannot Access |
 |---|---|---|---|
@@ -106,7 +128,7 @@ flutter_boilerplate/
 └── test/
 ```
 
-### `lib/shared/` — DEPRECATED
+### `lib/shared/` — DEPRECATED — see [ADR-0006](docs/adr/0006-feature-owned-singletons.md)
 
 `lib/shared/` currently contains `stores/` (auth_store, connectivity, notifications_store), `features/connection_wrapper`, `widgets/`, `modals/`, `state/`, `constants/`. **Do not add new files there.** New code belongs under the owning feature, regardless of singleton scope.
 
@@ -116,7 +138,7 @@ flutter_boilerplate/
 
 Existing `lib/shared/` files may be migrated opportunistically when touched.
 
-### No nested `features/` — features are peers
+### No nested `features/` — features are peers — see [ADR-0005](docs/adr/0005-flat-feature-tree.md)
 
 A feature must **never** contain a `features/` subdirectory. Sub-modules with their own store/state/view get promoted to siblings under the domain grouping.
 
@@ -153,6 +175,8 @@ Pure view-layer sub-pages (no store) can remain under `view/` (e.g., `meeting_de
 
 ### Navigation — NEVER use `context.router`
 
+Rationale + alternatives: [ADR-0008](docs/adr/0008-appnavigator-routing-abstraction.md).
+
 Always inject `AppNavigator` into state classes. Pages call state methods, never navigate directly.
 
 ```dart
@@ -172,6 +196,8 @@ abstract class _MyPageStateBase with Store {
 ```
 
 ### State Access — NEVER pass state as widget parameters
+
+Rationale + alternatives: [ADR-0009](docs/adr/0009-provider-based-state-access.md).
 
 Create `Provider` at the page root. Child widgets access via `context.read<T>()`.
 
@@ -225,13 +251,18 @@ bool get hasItems => _items.isNotEmpty;
 
 ### Dependency Injection
 
+Rationale + alternatives: [ADR-0007](docs/adr/0007-di-scopes-and-constructor-injection.md).
+
 - `@injectable` — feature-scoped (State classes, feature Stores, Use Cases)
-- `@singleton` — app-wide Stores (`AuthStore`, etc.) — still live under their owning feature's `mobx/`
+- `@singleton` — app-wide Stores (`AuthStore`, etc.) and `AppNavigator` — still live under their owning feature's `mobx/`
+- `@lazySingleton` — app-wide services constructed on first resolution (e.g. `DioService`)
 - Flavor-scope bindings with `@dev` / `@prod` — `configureDependencies(FlavorType)` passes the flavor name as the `environment` to injectable
 - Always inject via constructor. Never call `getIt<>()` inside classes (except at Widget→State boundary inside `Provider(create:)`)
 - `resetDependencies()` tears down GetIt and re-registers with current flavor — use for env switching
 
 ### Widgets — HookWidget over StatefulWidget
+
+Rationale + alternatives: [ADR-0010](docs/adr/0010-hookwidget-default.md).
 
 Use `HookWidget` for local state/lifecycle. Use `StatelessWidget` for pure presentation.
 
@@ -248,30 +279,11 @@ class _Content extends HookWidget {
 
 ## Use Cases
 
-Use cases (`*_use_case.dart`) encapsulate a single business operation. `@injectable` classes with a `call()` method.
+Use cases (`*_use_case.dart`) encapsulate a single business operation. `@injectable` classes with a `call()` method. Rationale + alternatives: [ADR-0003](docs/adr/0003-no-use-case-to-use-case-dependencies.md), [ADR-0004](docs/adr/0004-use-case-taxonomy-and-colocation.md).
 
-### Use Cases NEVER inject other Use Cases
-
-A use case only depends on services (`DioService`, `AppNavigator`, etc.) — never on another use case. Shared logic goes into a service or utility.
-
-```dart
-// ❌ FORBIDDEN
-class CopyNotesUseCase {
-  final CopyUseCase _copyUseCase; // UC → UC
-}
-
-// ✅ CORRECT
-class CopyNotesUseCase {
-  final AppNavigator _appNavigator;
-}
-```
-
-### 4 Types
-
-1. **API** — wraps one API call, handles `DioException`
-2. **Navigation** — wraps `AppNavigator` calls (modals, routes)
-3. **Service Coordination** — orchestrates 2+ services
-4. **State Delegation** — conditional flow/guard logic for multiple callers
+- **No UC → UC** — UC depends on services / stores / `AppNavigator`, never another UC. Shared logic becomes a service.
+- **4 types** — API / Navigation / Service Coordination / State Delegation.
+- **Place next to consumer** — see Location Rules below; promote on second consumer.
 
 ### Pattern
 
@@ -319,24 +331,28 @@ Rule: **place next to consumer.** Gains second consumer in different layer → p
 
 ## API Layer
 
+Rationale + alternatives: [ADR-0011](docs/adr/0011-retrofit-typed-api-layer.md).
+
 ### Retrofit Provider Pattern
 
 ```dart
 @RestApi()
-abstract class AuthApiProvider {
-  factory AuthApiProvider(Dio dio) = _AuthApiProvider;
+abstract class TodosApiProvider {
+  factory TodosApiProvider(Dio dio) = _TodosApiProvider;
 
-  @GET(_Paths.getUserProfile)
-  Future<BaseResponseDto<UserResponseDto>> getUserProfile();
+  @GET(_Paths.getTodos)
+  Future<List<TodoDto>> getTodos();
 }
 ```
 
-- Wrap responses in `BaseResponseDto<T>`
-- DTOs use `@freezed` + `@JsonKey` (json_serializable with `explicit_to_json: true`, `any_map: true` — see `build.yaml`)
+- Single-resource endpoints return the DTO directly; paginated lists return `ListResponseDto<T>` (see `packages/api/lib/src/models/list_response_entity/`)
+- DTOs are `@freezed sealed class` with `fromJson` factory (json_serializable `explicit_to_json: true`, `any_map: true` — see `build.yaml`)
 - Providers accessed only through `DioService` in Stores/Use Cases
-- Interceptors live in `lib/core/services/interceptors/` (app concerns: auth, logging)
+- Interceptors live in `lib/core/services/interceptors/` (app concerns: auth, logging, mocking)
 
 ## State vs Store Decision Tree
+
+Rationale + alternatives: [ADR-0002](docs/adr/0002-state-vs-store-separation.md).
 
 | Question | → State (`*_state.dart`) | → Store (`*_store.dart`) |
 |---|---|---|
@@ -345,6 +361,8 @@ abstract class AuthApiProvider {
 | Location? | `features/*/view/` | `features/*/mobx/` (always under owning feature) |
 
 ## Localization
+
+Rationale + alternatives: [ADR-0012](docs/adr/0012-mandatory-localization.md).
 
 Never hardcode text in UI. Always use `LocaleKeys.keyName.tr()`.
 
@@ -363,7 +381,7 @@ Add strings to `assets/translations/en-US.json`, then run `melos run translation
 - Themes (`lightTheme`, `darkTheme`) exposed from package root; both wired in `lib/app.dart`
 - Asset codegen lives in `design_system/lib/gen`; root app asset codegen in `lib/gen` via `flutter_gen`
 
-### No hardcoded colors or styles in `lib/` — NON-NEGOTIABLE
+### No hardcoded colors or styles in `lib/` — see [ADR-0013](docs/adr/0013-design-system-tokens-only.md)
 
 The `lib/` layer (app) must never contain raw `Color(0x…)` / hex literals, raw `TextStyle(…)` composites, or one-off shadow stacks. Every visual token lives in the design system package.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,5 +1,7 @@
 # Design System Inspired by Vercel
 
+> **Reference doc.** This file is the visual specification (palette, type scale, shadows, components). The *rule* that app code consumes only DS tokens — never raw colors or styles — is captured in [ADR-0013](docs/adr/0013-design-system-tokens-only.md). The *package boundary* (why `design_system` is its own workspace package) is in [ADR-0014](docs/adr/0014-melos-package-split.md).
+
 ## 1. Visual Theme & Atmosphere
 
 Vercel's website is the visual thesis of developer infrastructure made invisible — a design system so restrained it borders on philosophical. The page is overwhelmingly white (`#ffffff`) with near-black (`#171717`) text, creating a gallery-like emptiness where every element earns its pixel. This isn't minimalism as decoration; it's minimalism as engineering principle. The Geist design system treats the interface like a compiler treats code — every unnecessary token is stripped away until only structure remains.

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,44 @@
+# NNNN. Short Decision Title
+
+- Status: Proposed | Accepted | Deprecated | Superseded by ADR-XXXX
+- Date: YYYY-MM-DD
+- Deciders: <names or roles>
+
+## Context and Problem Statement
+
+What is the situation? What forces are at play? What problem must be solved? Two or three short paragraphs is enough.
+
+## Decision Drivers
+
+- driver 1
+- driver 2
+
+## Considered Options
+
+- Option A
+- Option B
+- Option C
+
+## Decision Outcome
+
+Chosen option: **Option X**, because <one-line justification>.
+
+### Consequences
+
+- Good: ...
+- Bad / trade-off: ...
+
+## Pros and Cons of the Options
+
+### Option A
+- Good: ...
+- Bad: ...
+
+### Option B
+- Good: ...
+- Bad: ...
+
+## Links
+
+- Related ADR: [ADR-XXXX](XXXX-slug.md)
+- External reference: <url>

--- a/docs/adr/0001-layered-architecture.md
+++ b/docs/adr/0001-layered-architecture.md
@@ -1,0 +1,75 @@
+# 1. Layered Architecture with Adjacent-Only Access
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+A Flutter app mixes presentation, business logic, navigation, persistence, and HTTP concerns. Without a clear seam between them, widgets reach into HTTP clients, business logic embeds widgets, and tests devolve into integration setups.
+
+This boilerplate must give every feature a predictable shape so reviewers know where a change belongs and tests can mock at the seam closest to the unit under test.
+
+## Decision Drivers
+
+- Reviewability — a reader should know which layer is responsible for a behavior in seconds.
+- Testability — UI tests should not require HTTP mocking; store tests should not require widget pumping.
+- Replaceability — swap HTTP client, swap navigation lib, swap state lib, without rewriting feature code.
+- Existing convention — the codebase already follows this layout; the ADR codifies it.
+
+## Considered Options
+
+- **Layered with adjacent-only access** (UI → State → Store → DioService → API Provider). Each layer talks only to its immediate neighbor.
+- **Hexagonal / ports-and-adapters**. Domain core plus inward-pointing adapters for UI, HTTP, persistence.
+- **Flat / pragmatic**. Widgets call API providers directly, no intermediate state class.
+
+## Decision Outcome
+
+Chosen option: **Layered with adjacent-only access**.
+
+The contract:
+
+```
+UI (page/widget) → State (*_state.dart) → Store (*_store.dart) → DioService → API Provider
+                                       ↘ Use Case ↗
+```
+
+Hard rules:
+
+- UI never touches `DioService` or stores directly. UI reads its `*_state.dart` via `context.read<T>()`.
+- State has no direct API access. It calls stores or use cases.
+- Stores own API access via `DioService` and may collaborate with other stores.
+- Use cases (`*_use_case.dart`) are an orthogonal seam between State/Store and services — they encapsulate one operation and may be invoked from State, Store, or a modal state per [ADR-0004](0004-use-case-taxonomy-and-colocation.md).
+
+### Consequences
+
+- Good: each layer has a single allowed downstream collaborator type, so dependency graphs stay shallow.
+- Good: tests target one layer at a time. State tests fake stores; store tests fake `DioService`.
+- Good: swapping HTTP, navigation, or state library is layer-local.
+- Bad: extra indirection for trivial features — a page that lists static data still gets a state class.
+- Bad: developers learning the codebase must internalize five layer roles before shipping.
+
+## Pros and Cons of the Options
+
+### Layered with adjacent-only access
+- Good: matches existing code; predictable for review.
+- Good: clean unit-test seams.
+- Bad: ceremony for trivial screens.
+
+### Hexagonal / ports-and-adapters
+- Good: maximum decoupling of domain from frameworks.
+- Bad: overkill for a Flutter UI app — domain logic is thin, most code is presentation + IO.
+- Bad: introduces ports/adapters/domain entities that duplicate DTOs.
+
+### Flat / pragmatic
+- Good: fastest to write a screen.
+- Bad: widgets become untestable without HTTP setup.
+- Bad: business logic spreads across `build()` methods and ad-hoc helpers.
+
+## Links
+
+- [ADR-0002 State vs Store separation](0002-state-vs-store-separation.md)
+- [ADR-0003 No use-case → use-case dependencies](0003-no-use-case-to-use-case-dependencies.md)
+- [ADR-0004 Use case taxonomy and colocation](0004-use-case-taxonomy-and-colocation.md)
+- [ADR-0009 Provider-based state access](0009-provider-based-state-access.md)
+- Code: [lib/core/services/dio_service.dart](../../lib/core/services/dio_service.dart), [packages/api](../../packages/api)

--- a/docs/adr/0002-state-vs-store-separation.md
+++ b/docs/adr/0002-state-vs-store-separation.md
@@ -1,0 +1,70 @@
+# 2. State vs Store Separation
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+MobX gives a single primitive (a class with `@observable` / `@action`) for both screen-local UI state and app-wide cross-feature state. Conflating those two roles produces stores that own modal flags, animation timers, navigation calls, and HTTP at the same time.
+
+We need a rule that tells a reader, at a glance, whether a class is a *page controller* or a *domain store*, and tells the writer where API access is allowed.
+
+## Decision Drivers
+
+- Lifetime mismatch — page state is short-lived (one route entry); domain data is app-wide.
+- API ownership — only one layer should own HTTP for a given resource, to keep caching and error handling consistent.
+- Testability — page-state tests should fake stores, not `Dio`.
+
+## Considered Options
+
+- **Two distinct types** — `*_state.dart` (per-page, no API) vs `*_store.dart` (feature/app-wide, owns API).
+- **Single MobX class per feature** — one store does both jobs.
+- **Riverpod-style providers** — replace MobX entirely.
+
+## Decision Outcome
+
+Chosen option: **Two distinct types**.
+
+| | `*_state.dart` | `*_store.dart` |
+|---|---|---|
+| Purpose | Per-page/modal UI state | Feature or app-wide domain data |
+| API access | No — calls stores or use cases | Yes — injects `DioService` |
+| DI | `@injectable` | `@injectable` (feature) or `@singleton` (app-wide) |
+| Location | `features/{f}/view/` or `features/{f}/modals/{m}/mobx/` | `features/{f}/mobx/` |
+| Lifetime | One screen entry | Bound to feature container or app |
+
+Rationale: an `AuthStore` outlives every login screen; a `LoginPageState` dies when the user navigates away. Putting both in the same class forces one of the two lifetimes to leak.
+
+`@readonly` private fields auto-generate the public getter — never hand-write a `@computed` mirror for them. `@computed` is reserved for *derived* state.
+
+### Consequences
+
+- Good: API ownership is concentrated in stores; pages can be tested without HTTP.
+- Good: singletons stay small (no per-screen flags pollute them).
+- Good: a quick filename glance reveals the role.
+- Bad: features with one screen still produce two MobX classes.
+- Bad: requires discipline to resist adding `Dio` to a state class "just this once".
+
+## Pros and Cons of the Options
+
+### Two distinct types
+- Good: clear API ownership and lifetime separation.
+- Bad: more files per feature.
+
+### Single MobX class per feature
+- Good: fewer files.
+- Bad: page-local flags leak into the singleton; tests pull HTTP into UI specs.
+- Bad: lifetime ambiguity — when does a singleton's "page state" reset?
+
+### Riverpod-style providers
+- Good: built-in scoping.
+- Bad: codebase-wide migration off MobX; loses code-gen integration with `mobx_codegen`.
+- Bad: introduces a second reactive primitive next to existing MobX.
+
+## Links
+
+- [ADR-0001 Layered architecture](0001-layered-architecture.md)
+- [ADR-0006 Feature-owned singletons](0006-feature-owned-singletons.md)
+- [ADR-0007 DI scopes and constructor injection](0007-di-scopes-and-constructor-injection.md)
+- Code: [lib/features/auth/mobx/auth_store.dart](../../lib/features/auth/mobx/auth_store.dart), [lib/features/home/view/home_page_state.dart](../../lib/features/home/view/home_page_state.dart)

--- a/docs/adr/0003-no-use-case-to-use-case-dependencies.md
+++ b/docs/adr/0003-no-use-case-to-use-case-dependencies.md
@@ -1,0 +1,66 @@
+# 3. Use Cases Never Depend on Other Use Cases
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+Use cases (`*_use_case.dart`) are single-operation classes invoked from State, Store, or modal-state. As features grow, the temptation appears to compose them: `CopyNotesUseCase` injects `CopyUseCase` to avoid duplicating clipboard logic.
+
+That introduces a graph of UC → UC dependencies, which: (1) makes test setup recursive (every UC test stubs N other UCs), (2) hides the real seam (a `Service` or utility), and (3) creates implicit ordering across UCs that aren't explicitly co-located.
+
+## Decision Drivers
+
+- Test setup cost — UCs should fake their *services*, not their *peers*.
+- Single responsibility — a UC is one operation; if it needs a peer, the peer is the operation, not a sub-step.
+- Discoverability — shared logic should live in an obviously-shared place (`Service`, utility, extension), not behind another UC name.
+
+## Considered Options
+
+- **Forbid UC → UC** — UC depends only on services, navigators, and stores. Shared logic lives in a service or utility.
+- **Allow shallow UC composition** — a UC may inject one UC, but no deeper.
+- **Allow free composition** — UCs form a free DAG.
+
+## Decision Outcome
+
+Chosen option: **Forbid UC → UC**.
+
+A use case may inject:
+- `DioService` and any feature/app store
+- `AppNavigator`
+- Any `*_service.dart` (e.g. `IssueTrackingService`, `FlavorService`)
+
+It must not inject another `*_use_case.dart`. When two UCs share logic, extract that logic to a service or top-level utility.
+
+Example — `CreateTodoUseCase` ([lib/features/home/modals/add_todo_modal/use_cases/create_todo_use_case.dart](../../lib/features/home/modals/add_todo_modal/use_cases/create_todo_use_case.dart)) takes only `DioService`. Adding clipboard support would not inject a `CopyUseCase`; it would inject a `ClipboardService`.
+
+### Consequences
+
+- Good: UC tests are flat — fake the services, call `useCase()`, assert.
+- Good: shared logic surfaces as a named service, not hidden behind a UC's `call()`.
+- Good: dependency graph stays a tree of UC → service, not a DAG of UC → UC → UC.
+- Bad: occasional duplication when two UCs would naturally share a single service-less helper.
+- Bad: requires extracting a service for what could have been a 3-line UC reuse.
+
+## Pros and Cons of the Options
+
+### Forbid UC → UC
+- Good: flat test setup; explicit shared seams.
+- Bad: occasional small extractions.
+
+### Allow shallow UC composition
+- Good: convenient for small reuse.
+- Bad: "shallow" decays — once allowed, the depth limit drifts.
+- Bad: still inverts the rule that shared logic is a *service*, not a *use case*.
+
+### Allow free composition
+- Good: maximum reuse.
+- Bad: tests become recursive mock setups.
+- Bad: cycles become possible; UC ordering becomes implicit.
+
+## Links
+
+- [ADR-0001 Layered architecture](0001-layered-architecture.md)
+- [ADR-0004 Use case taxonomy and colocation](0004-use-case-taxonomy-and-colocation.md)
+- [ADR-0007 DI scopes and constructor injection](0007-di-scopes-and-constructor-injection.md)

--- a/docs/adr/0004-use-case-taxonomy-and-colocation.md
+++ b/docs/adr/0004-use-case-taxonomy-and-colocation.md
@@ -1,0 +1,78 @@
+# 4. Use Case Taxonomy and Colocation by Consumer
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+Use cases proliferate. Without a taxonomy, every "thing that does something" becomes a `*_use_case.dart`, including trivial one-liners that belong inline. Without a placement rule, they pile into `lib/core/use_cases/` regardless of who consumes them, producing a directory disconnected from feature code.
+
+We need (a) when to extract a UC at all, (b) what kinds of UC exist, and (c) where each one lives.
+
+## Decision Drivers
+
+- Locality — a UC consumed by one state class should live next to that state class.
+- Promotion clarity — when a UC gains a second consumer, the move should be mechanical.
+- Test cohesion — tests live near the code, so the UC's home directory is also the test's home directory.
+
+## Considered Options
+
+- **Taxonomy + consumer-based colocation** — 4 UC types; placement follows the consumer layer; promote on second consumer.
+- **All UCs in `lib/core/use_cases/`** — one flat directory.
+- **No UC concept** — fold logic into stores or state directly.
+
+## Decision Outcome
+
+Chosen option: **Taxonomy + consumer-based colocation**.
+
+### Four types
+
+1. **API** — wraps one HTTP call, handles `DioException`. Example: [`CreateTodoUseCase`](../../lib/features/home/modals/add_todo_modal/use_cases/create_todo_use_case.dart).
+2. **Navigation** — wraps `AppNavigator` calls (modals, routes). Example: [`ShowAddTodoModalUseCase`](../../lib/features/home/view/use_cases/show_add_todo_modal_use_case.dart).
+3. **Service Coordination** — orchestrates 2+ services (HTTP + analytics + tracking).
+4. **State Delegation** — conditional flow/guard logic invoked from multiple callers.
+
+### Location rules
+
+| Consumer | Path |
+|---|---|
+| Store only | `lib/features/{feature}/mobx/use_cases/` |
+| State / View only | `lib/features/{feature}/view/use_cases/` |
+| Modal only | `lib/features/{feature}/modals/{modal}/use_cases/` |
+| Multiple layers within one feature | `lib/features/{feature}/core/use_cases/` |
+| Multiple features | `lib/core/use_cases/` |
+
+Promotion rule: gains a consumer in a different layer of the same feature → promote one level. Gains a consumer in a different feature → promote to [`lib/core/use_cases/`](../../lib/core/use_cases). Today's only cross-feature UC is [`OpenTodoDetailsUseCase`](../../lib/core/use_cases/open_todo_details_use_case.dart).
+
+### Extract vs keep inline
+
+Extract when the operation is reused in 2+ places, coordinates 2+ services, or is complex enough for its own test. Keep inline for trivial one-line delegation.
+
+### Consequences
+
+- Good: a UC's home matches the file that calls it — discovery is local.
+- Good: promotion is rule-based, not taste-based.
+- Good: `lib/core/use_cases/` stays small and intentional (cross-feature only).
+- Bad: file moves on second-consumer promotion produce churn in git history.
+- Bad: developers must classify before placing — easy to put a navigation UC in `view/use_cases/` when it's really used by a store.
+
+## Pros and Cons of the Options
+
+### Taxonomy + consumer-based colocation
+- Good: locality and a deterministic promotion path.
+- Bad: occasional file moves.
+
+### All UCs in `lib/core/use_cases/`
+- Good: one place to look.
+- Bad: directory grows unbounded; tests detach from the feature they cover; reuse appears artificially common.
+
+### No UC concept
+- Good: fewer files.
+- Bad: stores and states bloat with cross-cutting concerns (HTTP error handling, modal coordination) that have no natural home in either.
+
+## Links
+
+- [ADR-0001 Layered architecture](0001-layered-architecture.md)
+- [ADR-0003 No use-case → use-case dependencies](0003-no-use-case-to-use-case-dependencies.md)
+- [ADR-0005 Flat feature tree](0005-flat-feature-tree.md)

--- a/docs/adr/0005-flat-feature-tree.md
+++ b/docs/adr/0005-flat-feature-tree.md
@@ -1,0 +1,70 @@
+# 5. Flat Feature Tree (No Nested `features/`)
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+A feature can grow sub-modules — for example, a meeting feature may sprout an AI-chat sub-module with its own store, state, and view. The shortest path to organize that is a nested `features/` directory inside the parent feature. Done repeatedly, the tree becomes a recursive maze where the same naming patterns appear at multiple depths and DI scoping becomes unclear.
+
+We need a rule that says *features are peers*, not parents and children.
+
+## Decision Drivers
+
+- Predictable depth — `lib/features/{feature}/{layer}/...` is a known shape; deeper nesting breaks tooling expectations and grep paths.
+- DI clarity — feature scoping is one level deep; nesting forces sub-feature DI scopes nobody actually configures.
+- Discoverability — top-level `lib/features/` listing should surface every feature.
+
+## Considered Options
+
+- **Flat — features are peers under a domain grouping**.
+- **Nested — `features/` allowed inside any feature**.
+- **Domain folders without `features/`** — `lib/meetings/{ai_chat,details}/` without a `features/` parent at all.
+
+## Decision Outcome
+
+Chosen option: **Flat — features are peers under a domain grouping**.
+
+```
+# ❌ Wrong — nested features
+lib/features/meetings/meeting_details/features/ai_chat/
+
+# ✅ Correct — peer features
+lib/features/meetings/ai_chat/
+lib/features/meetings/meeting_details/
+```
+
+A feature with its own store/state/view is a feature, not a sub-module. Promote it to a sibling under the domain grouping.
+
+Pure view-layer sub-pages (no store, no state class) may remain under the parent's `view/` — for example, `meeting_details/view/share_meeting/` is fine because it has no MobX class of its own.
+
+This codebase's current features are already flat: [`lib/features/`](../../lib/features/) holds `app`, `auth`, `challenges`, `home`, `splash`, `todo_details` as peers. Modals nest inside their owning feature (`home/modals/add_todo_modal/`), but a *modal* is not a feature — it has no route, no router config, and no top-level entry.
+
+### Consequences
+
+- Good: every feature appears at one known depth; tooling and search paths stay shallow.
+- Good: no ambiguity over which DI scope a class belongs to.
+- Good: refactor "is this a feature?" answered by directory location, not annotation.
+- Bad: closely related sub-modules sit as siblings instead of nesting visually.
+- Bad: domain grouping can grow wide (many peers under `meetings/`) before someone splits the domain.
+
+## Pros and Cons of the Options
+
+### Flat
+- Good: one shape, predictable depth.
+- Bad: wider directories at the domain level.
+
+### Nested `features/`
+- Good: visual grouping of parent + children.
+- Bad: recursive structure; same names recur at multiple depths.
+- Bad: DI scopes for "child features" are never actually wired.
+
+### Domain folders without `features/`
+- Good: shorter paths.
+- Bad: mixes app-level and feature-level conventions; no single place to enumerate features.
+
+## Links
+
+- [ADR-0001 Layered architecture](0001-layered-architecture.md)
+- [ADR-0006 Feature-owned singletons](0006-feature-owned-singletons.md)

--- a/docs/adr/0006-feature-owned-singletons.md
+++ b/docs/adr/0006-feature-owned-singletons.md
@@ -1,0 +1,74 @@
+# 6. Feature-Owned Singletons (no `lib/shared/`)
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+App-wide singletons — auth, connectivity, notifications — are long-lived and reachable from many features. The traditional Flutter habit puts them in a top-level `lib/shared/` (or `lib/global/`, `lib/common/`) directory because their *scope* is global.
+
+That directory then becomes the dumping ground for "anything used by more than one feature": a few singletons, then some shared widgets, then orphaned models, then a `state/` dir for cross-cutting flags. Ownership becomes ambiguous; nobody owns "the shared dir".
+
+## Decision Drivers
+
+- Ownership — every store has one feature that conceptually owns it (auth code owns `AuthStore`).
+- Scope ≠ location — singleton scope is a DI annotation, not a directory.
+- Consistency — one rule for where stores live, regardless of lifetime.
+
+## Considered Options
+
+- **Feature-owned singletons** — singletons live under their owning feature's `mobx/`, scoped via `@singleton`.
+- **`lib/shared/` for singletons** — top-level dir for app-wide stores.
+- **`lib/core/state/` for singletons** — under `core/` next to services.
+
+## Decision Outcome
+
+Chosen option: **Feature-owned singletons**.
+
+Every store, regardless of DI scope, lives at `lib/features/{owning_feature}/mobx/`. Lifetime is encoded in the annotation, not the path:
+
+App-wide stores (per [ADR-0002](0002-state-vs-store-separation.md), `*_store.dart`):
+
+| Store | Path | Annotation |
+|---|---|---|
+| [`AuthStore`](../../lib/features/auth/mobx/auth_store.dart) | `lib/features/auth/mobx/` | `@singleton` |
+| [`HomeStore`](../../lib/features/home/mobx/home_store.dart) | `lib/features/home/mobx/` | `@singleton` |
+| [`NotificationsStore`](../../lib/features/app/mobx/notifications_store.dart) | `lib/features/app/mobx/` | `@singleton` |
+| [`ConnectivityStore`](../../lib/features/app/mobx/connectivity_store.dart) | `lib/features/app/mobx/` | `@singleton` |
+
+`ConnectionWrapperState` (`lib/features/app/mobx/connection_wrapper_state.dart`) lives in the same directory but is `@injectable`, not a singleton — it is the connection-wrapper page's state class, included here to show that the `mobx/` directory holds both `*_store.dart` (app-wide) and `*_state.dart` for app-feature widgets.
+
+The `lib/features/app/` feature exists specifically to own genuinely app-level concerns (connectivity, notifications, app-update modal) without a `lib/shared/` directory.
+
+`lib/shared/` is **deprecated** and not present in the current tree — do not add it back. Existing widgets used cross-feature go in [`lib/core/ui/`](../../lib/core/ui); cross-feature models in [`lib/core/`](../../lib/core); cross-feature use cases in [`lib/core/use_cases/`](../../lib/core/use_cases).
+
+### Consequences
+
+- Good: every store has an obvious owning feature.
+- Good: new contributors find auth code in `features/auth/`, not in two places.
+- Good: removing a feature removes its singleton with it.
+- Bad: a store used heavily by every feature still nominally "belongs" to one feature (e.g. `AuthStore` in `auth/`).
+- Bad: requires the `app/` feature as a home for genuinely cross-cutting concerns (connectivity, notifications) that don't belong to a domain feature.
+
+## Pros and Cons of the Options
+
+### Feature-owned singletons
+- Good: scope-vs-location decoupling; consistent placement rule.
+- Bad: occasional "which feature owns this?" debates.
+
+### `lib/shared/`
+- Good: matches habit from many Flutter samples.
+- Bad: becomes a dumping ground; ownership erodes.
+- Bad: same store can plausibly live in `shared/` or `features/x/` — two valid paths.
+
+### `lib/core/state/`
+- Good: groups all singletons.
+- Bad: `core/` is for framework-level concerns (services, navigation, DI bootstrap), not domain stores.
+- Bad: separates a feature's store from its state classes and use cases.
+
+## Links
+
+- [ADR-0001 Layered architecture](0001-layered-architecture.md)
+- [ADR-0002 State vs Store separation](0002-state-vs-store-separation.md)
+- [ADR-0007 DI scopes and constructor injection](0007-di-scopes-and-constructor-injection.md)

--- a/docs/adr/0007-di-scopes-and-constructor-injection.md
+++ b/docs/adr/0007-di-scopes-and-constructor-injection.md
@@ -1,0 +1,65 @@
+# 7. DI Scopes and Constructor Injection
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+GetIt + Injectable gives several knobs: `@injectable`, `@singleton`, `@lazySingleton`, factory params, named registrations, environments. Without a rule, every author picks a different combination and the DI graph becomes inconsistent. Worse, code calling `getIt<T>()` from inside business classes turns DI into an ambient service locator, breaking testability.
+
+We also need flavor-aware bindings — `dev` vs `prod` — without scattering `if (isDev)` throughout the app.
+
+## Decision Drivers
+
+- Testability — constructor injection makes a class testable with plain Dart fakes; service-locator calls require mocking the locator.
+- Predictable lifetimes — small set of scopes: per-resolution (`@injectable`), app-wide eager (`@singleton`), app-wide lazy (`@lazySingleton`).
+- Flavor handling — env-specific bindings should be declarative, not branching at the call site.
+
+## Considered Options
+
+- **Constructor injection only, three injectable scopes (`@injectable`, `@singleton`, `@lazySingleton`), env via injectable environments**.
+- **Service locator everywhere** — call `getIt<T>()` inside classes.
+- **Riverpod / Provider tree only** — no GetIt.
+
+## Decision Outcome
+
+Chosen option: **Constructor injection, three injectable scopes (`@injectable`, `@singleton`, `@lazySingleton`), env-scoped bindings**.
+
+Rules:
+
+- `@injectable` for State classes, feature stores, use cases — new instance on resolution.
+- `@singleton` for app-wide stores (`AuthStore`, `HomeStore`, `NotificationsStore`, `ConnectivityStore`) and for [`AppNavigator`](../../lib/core/navigation/app_navigator.dart) — eagerly registered at startup.
+- `@lazySingleton` for app-wide services that are expensive or rarely used and acceptable to construct on first resolution. Current example: [`DioService`](../../lib/core/services/dio_service.dart). Prefer `@singleton` by default; reach for `@lazySingleton` only when eager construction is wasteful.
+- Always inject via constructor. Never call `getIt<>()` inside a class — except at the Widget→State boundary inside `Provider(create:)`, which is the one allowed seam (see [ADR-0009](0009-provider-based-state-access.md)).
+- Flavor-specific bindings annotated with `@dev` / `@prod`. Bootstrap is [`configureDependencies(FlavorType)`](../../lib/injectable.dart) which passes the flavor name as the injectable `environment`. [`resetDependencies()`](../../lib/injectable.dart) tears down GetIt and re-registers under the current flavor — used when the user switches environment at runtime.
+
+### Consequences
+
+- Good: classes are unit-testable with plain constructor stubs; no `getIt` mocking.
+- Good: two scopes only — readers don't have to reason about lazy vs eager singletons.
+- Good: flavor differences declared at registration sites, not at consumption sites.
+- Bad: large constructors when a class needs many collaborators (forces extraction).
+- Bad: developers learning the codebase must remember the one allowed `getIt<>()` site (`Provider(create:)`).
+
+## Pros and Cons of the Options
+
+### Constructor injection, three scopes
+- Good: testable; no ambient locator usage.
+- Bad: long constructor parameter lists for collaborator-heavy classes.
+- Bad: `@lazySingleton` vs `@singleton` is a judgement call — gets misused as "the safer default" until startup time regresses.
+
+### Service locator everywhere
+- Good: zero constructor noise.
+- Bad: hidden dependencies; tests must mock the locator; refactors are silent.
+
+### Riverpod / Provider tree only
+- Good: scoped overrides per widget subtree.
+- Bad: codebase migration cost; loses `injectable` codegen for non-widget classes (use cases, services).
+
+## Links
+
+- [ADR-0002 State vs Store separation](0002-state-vs-store-separation.md)
+- [ADR-0006 Feature-owned singletons](0006-feature-owned-singletons.md)
+- [ADR-0009 Provider-based state access](0009-provider-based-state-access.md)
+- Code: [lib/injectable.dart](../../lib/injectable.dart), [lib/core/services/get_it.dart](../../lib/core/services/get_it.dart)

--- a/docs/adr/0008-appnavigator-routing-abstraction.md
+++ b/docs/adr/0008-appnavigator-routing-abstraction.md
@@ -1,0 +1,77 @@
+# 8. `AppNavigator` Routing Abstraction
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+`auto_route` exposes navigation through `context.router`, which is convenient inside widgets but couples every page to the routing library and ties navigation calls to the `BuildContext`. Tests of state classes can't drive navigation without pumping a widget tree; swapping the routing library means rewriting every `context.router.push(...)` site.
+
+The boilerplate already wraps navigation behind `AppNavigator` — this ADR captures why and pins the rule.
+
+## Decision Drivers
+
+- Testability — state classes own navigation; their tests should not pump widgets.
+- Decoupling — features depend on navigation behavior, not on `auto_route` specifics.
+- Single ownership — one class owns route configuration; pages don't reach into the router.
+
+## Considered Options
+
+- **`AppNavigator` wrapper, single `@singleton`, injected into states**.
+- **`context.router` everywhere** — pages call `auto_route` directly.
+- **Mixed — `AppNavigator` for cross-feature flows, `context.router` for in-feature**.
+
+## Decision Outcome
+
+Chosen option: **`AppNavigator` wrapper**.
+
+[`AppNavigator`](../../lib/core/navigation/app_navigator.dart) is a `@singleton` that owns the `AppRouter` and exposes `push`, `pop`, `popUntilRoot`, `popUntilRouteWithName`, `navigatePath`, etc. It is injected into state classes via constructor, never resolved through `context`.
+
+Hard rules:
+
+- Pages **never** call `context.router` directly.
+- Pages call methods on their state class; the state class calls `AppNavigator`.
+- `AppNavigator.config` (a `RouterConfig<UrlState>`) is consumed once by `MaterialApp.router` in [`lib/app.dart`](../../lib/app.dart).
+
+```dart
+// ❌ Forbidden in a page
+context.router.push(const SettingsRoute());
+
+// ✅ Correct — in *_state.dart
+abstract class _SettingsPageStateBase with Store {
+  final AppNavigator _appNavigator;
+  _SettingsPageStateBase(this._appNavigator);
+
+  @action
+  void openProfile() => _appNavigator.push(const ProfileRoute());
+}
+```
+
+### Consequences
+
+- Good: state-class tests drive navigation by stubbing `AppNavigator` — no widget pumping.
+- Good: routing-library swap is one file, not a sweep across the codebase.
+- Good: navigation calls appear only in state classes — easy to audit.
+- Bad: trivial pushes still go through a state method.
+- Bad: `AppNavigator`'s API surface grows over time (every new navigation primitive needs a method).
+
+## Pros and Cons of the Options
+
+### `AppNavigator` wrapper
+- Good: testable, decoupled, single source of truth.
+- Bad: indirection for trivial navigation.
+
+### `context.router` everywhere
+- Good: zero indirection.
+- Bad: state-class tests require widget tree; routing-library swap is a sweep.
+
+### Mixed
+- Good: lets simple navigation stay terse.
+- Bad: arbitrary line; "in-feature" definition drifts; reviewers can't tell which side a call should be on.
+
+## Links
+
+- [ADR-0001 Layered architecture](0001-layered-architecture.md)
+- [ADR-0007 DI scopes and constructor injection](0007-di-scopes-and-constructor-injection.md)
+- Code: [lib/core/navigation/app_navigator.dart](../../lib/core/navigation/app_navigator.dart), [lib/core/navigation/app_router.dart](../../lib/core/navigation/app_router.dart)

--- a/docs/adr/0009-provider-based-state-access.md
+++ b/docs/adr/0009-provider-based-state-access.md
@@ -1,0 +1,85 @@
+# 9. Provider-Based State Access in Widgets
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+A page's state class (`*_state.dart`) is consumed by many widgets in the page tree — content, header, dialogs, footers. Two ways to wire it: pass the state down as constructor arguments, or expose it through `Provider` once at the page root and let descendants read it via `context.read<T>()`.
+
+Passing state down forces every intermediate widget to declare a parameter it does not use. It also tightly couples widgets to a specific state class — refactoring or reusing a section means rewriting its constructor signature.
+
+## Decision Drivers
+
+- Refactor cost — extracting or moving widgets should not ripple through constructor signatures.
+- Reuse — `_Header`, `_Footer`, etc., should not need a state-class parameter to compile.
+- DI seam — there should be one allowed `getIt<>()` site (the page root), not many.
+
+## Considered Options
+
+- **`Provider` at the page root, `context.read<T>()` in descendants**.
+- **Constructor parameters all the way down**.
+- **`InheritedWidget` hand-rolled per state class**.
+- **MobX `Observer` rebuild + locator inside each widget**.
+
+## Decision Outcome
+
+Chosen option: **`Provider` at the page root**.
+
+The page widget (a `StatelessWidget` or `HookWidget`) creates a `Provider<MyPageState>` whose `create:` resolves the state from `getIt`, calls `init()`, and disposes it on unmount. Descendant widgets read it with `context.read<MyPageState>()` (or `context.watch<...>()` for rebuilding consumers).
+
+This is the single allowed `getIt<>()` site outside DI bootstrap (per [ADR-0007](0007-di-scopes-and-constructor-injection.md)).
+
+```dart
+class MyPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Provider(
+      create: (_) => getIt<MyPageState>()..init(),
+      dispose: (_, value) => value.dispose(),
+      child: const _Content(),
+    );
+  }
+}
+
+class _Content extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final state = context.read<MyPageState>();
+    return Scaffold(/* ... */);
+  }
+}
+```
+
+### Consequences
+
+- Good: descendant widgets are decoupled from the state class — refactor and extract freely.
+- Good: one place that calls `getIt`, easy to audit.
+- Good: state lifecycle (`init` / `dispose`) is bound to the `Provider` lifetime, not to a manually-managed `StatefulWidget`.
+- Bad: a widget that forgets to wrap its subtree with the right `Provider` fails at runtime, not compile time.
+- Bad: requires the `provider` package as a dependency.
+
+## Pros and Cons of the Options
+
+### `Provider` at the page root
+- Good: one resolution site, free reuse of widgets.
+- Bad: runtime failure on missing provider.
+
+### Constructor parameters all the way down
+- Good: compile-time safety.
+- Bad: every intermediate widget grows a parameter; reuse impossible without renaming the parameter.
+
+### Hand-rolled `InheritedWidget`
+- Good: no extra dependency.
+- Bad: boilerplate per state class (`updateShouldNotify`, `of(context)`); reinvents `provider`.
+
+### `Observer` + locator per widget
+- Good: no provider tree.
+- Bad: every widget calls `getIt`, which spreads service-locator usage and breaks the rule from ADR-0007.
+
+## Links
+
+- [ADR-0001 Layered architecture](0001-layered-architecture.md)
+- [ADR-0007 DI scopes and constructor injection](0007-di-scopes-and-constructor-injection.md)
+- [ADR-0010 `HookWidget` default](0010-hookwidget-default.md)

--- a/docs/adr/0010-hookwidget-default.md
+++ b/docs/adr/0010-hookwidget-default.md
@@ -1,0 +1,72 @@
+# 10. `HookWidget` as the Default Stateful Widget
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+Most "stateful" widgets in this app need lightweight local concerns: a `TextEditingController`, a `ScrollController`, a `useEffect` to subscribe/unsubscribe, an animation controller. `StatefulWidget` answers all of these but with a verbose `State<T>` class, manual `initState` / `dispose`, and lifecycle bugs (forgot to dispose, late init order).
+
+`flutter_hooks` collapses all four into composable hooks (`useTextEditingController`, `useScrollController`, `useEffect`, `useAnimationController`) with automatic disposal. Domain state already lives in MobX; widget-local concerns rarely justify a full `State<T>` class.
+
+## Decision Drivers
+
+- Less ceremony for common patterns (controllers, effects).
+- Automatic resource disposal — no leaked controllers.
+- Composable extraction — custom hooks vs custom `State<T>` subclass.
+
+## Considered Options
+
+- **`HookWidget` as default for any non-pure widget; `StatelessWidget` for pure presentation**.
+- **`StatefulWidget` always; ban hooks**.
+- **Mix freely with no policy**.
+
+## Decision Outcome
+
+Chosen option: **`HookWidget` default; `StatelessWidget` for pure presentation**.
+
+- Pure presentation (no controllers, no effects, no local mutable state) → `StatelessWidget`.
+- Anything that needs a controller, an effect, a local `useState`, or animation → `HookWidget`.
+- `StatefulWidget` is allowed only when interacting with APIs that genuinely need a `State<T>` lifecycle method not available as a hook (rare).
+
+```dart
+class _Content extends HookWidget {
+  @override
+  Widget build(BuildContext context) {
+    final controller = useTextEditingController();
+    useEffect(() {
+      final sub = stream.listen(_handle);
+      return sub.cancel;
+    }, const []);
+    return TextField(controller: controller);
+  }
+}
+```
+
+### Consequences
+
+- Good: shorter widget files; no manual disposal bugs.
+- Good: extractable hooks let multiple widgets share lifecycle logic without inheritance.
+- Good: matches the codebase's existing widgets — see [Quick Navigation in CLAUDE.md](../../CLAUDE.md).
+- Bad: `flutter_hooks` adds a dependency and a small learning curve for `useEffect` keys / dependencies.
+- Bad: stack traces include hook-internal frames when a hook misuse triggers a runtime error.
+
+## Pros and Cons of the Options
+
+### `HookWidget` default
+- Good: terse, automatic disposal, composable.
+- Bad: extra dependency; one more concept to learn.
+
+### `StatefulWidget` always
+- Good: zero added dependencies.
+- Bad: verbose; manual `dispose` is bug-prone; controller setup boilerplate everywhere.
+
+### Mix freely with no policy
+- Bad: two patterns for the same thing in adjacent files; reviewers can't tell which to use.
+
+## Links
+
+- [ADR-0001 Layered architecture](0001-layered-architecture.md)
+- [ADR-0009 Provider-based state access](0009-provider-based-state-access.md)
+- External: [flutter_hooks](https://pub.dev/packages/flutter_hooks)

--- a/docs/adr/0011-retrofit-typed-api-layer.md
+++ b/docs/adr/0011-retrofit-typed-api-layer.md
@@ -1,0 +1,102 @@
+# 11. Retrofit + Freezed Typed API Layer
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+The app talks to several HTTP backends. Hand-rolled `Dio.get(...)` calls scattered across stores produce three problems: (1) request building duplicated per call site, (2) JSON decoding inline with business logic, (3) DTO contracts implicit and untyped.
+
+A typed API layer with code generation removes the boilerplate, centralizes DTOs, and gives compile-time guarantees about request and response shapes.
+
+## Decision Drivers
+
+- Single contract — DTOs are the boundary between app and HTTP, owned in one package.
+- Compile-time typing — bad request bodies fail at build, not at runtime.
+- Pagination handling — paginated lists need a uniform helper, not ad-hoc `data` / `meta` parsing.
+
+## Considered Options
+
+- **Retrofit + freezed sealed DTOs in a separate `packages/api` module**.
+- **Hand-rolled `Dio` calls per store**.
+- **OpenAPI codegen (`openapi-generator`, `chopper` w/ generated client)**.
+
+## Decision Outcome
+
+Chosen option: **Retrofit + freezed sealed DTOs in `packages/api`**.
+
+### Provider pattern
+
+```dart
+@RestApi()
+abstract class TodosApiProvider {
+  factory TodosApiProvider(Dio dio) = _TodosApiProvider;
+
+  @GET(_Paths.getTodos)
+  Future<List<TodoDto>> getTodos();
+
+  @POST(_Paths.createTodo)
+  Future<TodoDto> createTodo({
+    @Body() required TodoCreateRequestDto todoCreateDto,
+  });
+}
+```
+
+Real example: [`TodosApiProvider`](../../packages/api/lib/src/providers/todos_provider/todos_api_provider.dart). Each provider lives under `packages/api/lib/src/providers/{name}_provider/` with its provider-specific DTOs in a sibling `models/` directory. DTOs shared across providers (e.g. [`ListResponseDto`](../../packages/api/lib/src/models/list_response_entity/list_response_entity.dart), `MetaDto`) live at `packages/api/lib/src/models/`.
+
+### DTO pattern
+
+DTOs are `@freezed sealed class`es with `fromJson` factories. `build.yaml` enables `any_map: true` and `explicit_to_json: true` so nested DTOs serialize correctly and the JSON decoder accepts non-`Map<String, dynamic>` shapes.
+
+```dart
+@freezed
+sealed class TodoDto with _$TodoDto {
+  factory TodoDto({
+    required String id,
+    required String title,
+    required bool completed,
+  }) = _TodoDto;
+
+  factory TodoDto.fromJson(Map<String, dynamic> json) =>
+      _$TodoDtoFromJson(json);
+}
+```
+
+### Pagination envelope
+
+Paginated responses use a generic [`ListResponseDto<T>`](../../packages/api/lib/src/models/list_response_entity/list_response_entity.dart) with `data: List<T>` and an optional `MetaDto`, plus a `parsedData(old)` extension that merges page 1 vs subsequent pages. Single-resource endpoints return the DTO directly; there is no universal response envelope.
+
+> **Known oddity:** `ListResponseDto` and `MetaDto` currently declare `implements Exception`. This ADR codifies the *envelope shape*, not the `Exception` declaration — that looks like a vestigial artifact and is not part of the intended contract. Treat it as a follow-up cleanup; do not propagate the pattern to new DTOs.
+
+### Access boundary
+
+API providers are reached only through [`DioService`](../../lib/core/services/dio_service.dart) in stores and use cases. Interceptors (auth, logging, mocking) live in [`lib/core/services/interceptors/`](../../lib/core/services/interceptors/) — app-side concerns belong in the app, not in the `packages/api` package.
+
+### Consequences
+
+- Good: typed request/response surface; DTO mismatches fail at build.
+- Good: providers and DTOs sit in their own package, decoupled from the app.
+- Good: `melos exec --scope api -- "dart run build_runner build -d"` runs codegen for the API package alone.
+- Bad: every endpoint requires an annotation + a codegen run — friction for one-off requests.
+- Bad: DTOs use freezed code generation; build_runner cycles add wall-clock time on first build.
+
+## Pros and Cons of the Options
+
+### Retrofit + freezed
+- Good: typed; single package; codegen pays for itself at scale.
+- Bad: codegen friction; generic `ListResponseDto<T>` requires a custom converter for `T`.
+
+### Hand-rolled `Dio`
+- Good: zero codegen.
+- Bad: duplicated request building; untyped responses; JSON parsing leaks into stores.
+
+### OpenAPI codegen
+- Good: server contract is the source of truth.
+- Bad: requires a maintained OpenAPI spec; generated clients are bulky and harder to customize per endpoint.
+
+## Links
+
+- [ADR-0001 Layered architecture](0001-layered-architecture.md)
+- [ADR-0014 Melos package split](0014-melos-package-split.md)
+- Code: [packages/api](../../packages/api), [lib/core/services/dio_service.dart](../../lib/core/services/dio_service.dart)

--- a/docs/adr/0012-mandatory-localization.md
+++ b/docs/adr/0012-mandatory-localization.md
@@ -1,0 +1,72 @@
+# 12. Mandatory Localization (No Hardcoded UI Strings)
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+User-facing strings start as English literals during a feature's first iteration. If the codebase tolerates inline strings, retrofitting localization later means a sweep across hundreds of files, frequent regressions ("forgot this Snackbar"), and ad-hoc keys that don't follow any scheme.
+
+Banning hardcoded UI strings from day one keeps the localization debt at zero.
+
+## Decision Drivers
+
+- Avoid retrofit cost — adding a locale shouldn't require rewriting widget files.
+- Compile-time key references — typos in string keys should fail at build, not at runtime.
+- Single workflow — one tool, one JSON file format, one key generator.
+
+## Considered Options
+
+- **`easy_localization` + `LocaleKeys` codegen, mandatory for every UI string**.
+- **Hardcode strings, internationalize later**.
+- **Flutter's `intl` + ARB files**.
+
+## Decision Outcome
+
+Chosen option: **`easy_localization` + `LocaleKeys` codegen**.
+
+Workflow:
+
+1. Add the string to `assets/translations/en-US.json` (add other locale files as needed). Supported locales are enumerated in [`lib/core/constants/supported_locals.dart`](../../lib/core/constants/supported_locals.dart).
+2. Run `melos run translations`. This regenerates [`lib/gen/locale_keys.g.dart`](../../lib/gen/locale_keys.g.dart) — never edit this file by hand.
+3. Use the generated key in UI: `Text(LocaleKeys.loginPage_title.tr())`.
+
+Hard rule: **no inline string literals in `Text(...)`, `Snackbar`, `AppBar(title:)`, error messages, or any other user-facing surface**. Tooltips, semantic labels, modal copy — all routed through `LocaleKeys`.
+
+```dart
+// ❌ Forbidden
+Text('Continue with email')
+
+// ✅ Required
+Text(LocaleKeys.loginPage_continueWithEmail.tr())
+```
+
+The bootstrap path in [`lib/main.dart`](../../lib/main.dart) calls `EasyLocalization.ensureInitialized()` before `runApp`, and [`lib/app.dart`](../../lib/app.dart) wires the `EasyLocalization` widget into the app root.
+
+### Consequences
+
+- Good: zero localization debt. Adding a locale is a translation task, not an engineering project.
+- Good: typos in keys break the build (the generated `LocaleKeys` field doesn't exist).
+- Good: every string lives in one auditable JSON file per locale.
+- Bad: trivial debug strings still cost a key + codegen run.
+- Bad: codegen step (`melos run translations`) is required before the keys appear, which slows down "just add a label" PRs.
+
+## Pros and Cons of the Options
+
+### `easy_localization` + `LocaleKeys`
+- Good: typed keys; single JSON; existing wiring.
+- Bad: codegen friction.
+
+### Hardcode now, internationalize later
+- Good: fastest path to ship.
+- Bad: retrofit cost grows with the codebase; regressions inevitable.
+
+### Flutter `intl` + ARB
+- Good: official Flutter approach; rich plural / select syntax.
+- Bad: more verbose generator setup; ARB tooling less ergonomic for non-localizers; requires migrating existing JSON content.
+
+## Links
+
+- [ADR-0001 Layered architecture](0001-layered-architecture.md)
+- Code: [lib/gen/locale_keys.g.dart](../../lib/gen/locale_keys.g.dart), [assets/translations/en-US.json](../../assets/translations/en-US.json)

--- a/docs/adr/0013-design-system-tokens-only.md
+++ b/docs/adr/0013-design-system-tokens-only.md
@@ -1,0 +1,77 @@
+# 13. Design-System Tokens Only in `lib/`
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+Once a `Color(0xFF...)` literal slips into a feature widget, it spreads. Each new feature copies the nearest neighbor; visual inconsistency compounds; dark-mode support requires hunting every literal across `lib/`. The same applies to ad-hoc `TextStyle(...)` composites, hand-rolled `BoxShadow` stacks, and arbitrary `Duration` values.
+
+The remedy is a hard rule: every visual token comes from the design-system package — no exceptions in app code.
+
+## Decision Drivers
+
+- Visual consistency — designers control tokens in one place; app code consumes them.
+- Dark-mode parity — every token has a light and a dark value, accessed through `ThemeExtension`s.
+- WCAG AA compliance — token pairs are auditable; ad-hoc colors are not.
+
+## Considered Options
+
+- **DS tokens only — every color/style/shadow/radius/duration comes from `packages/design_system`**.
+- **Tokens + escape hatches — bare hex allowed for "one-off" cases**.
+- **Per-feature mini-themes — features define their own colors when needed**.
+
+## Decision Outcome
+
+Chosen option: **DS tokens only**.
+
+The `lib/` layer must not contain raw `Color(0x…)` / hex literals, raw `TextStyle(...)` composites, or one-off shadow stacks. All tokens come from `packages/design_system`:
+
+| Token kind | Access | Add new tokens in |
+|---|---|---|
+| Colors | `context.geist.<token>` (Geist palette) or legacy `context.<token>` (Tailor `CustomTheme`) | `packages/design_system/lib/src/theme/src/` — both light + dark values |
+| Typography | `GeistTextStyles.<role>` or `context.<textStyle>` | `GeistTextStyles` (geist) or `TextStyles` (legacy) |
+| Radii | `GeistRadius.<scale>` | DS package |
+| Durations | `GeistDuration.<speed>` | DS package |
+| Shadows / elevation | `context.geist.cardShadow`, `shadowBorder`, `shadowFab`, etc. | `GeistTheme` extension |
+| Spacing | `kSpacingNpx` constants | `design_system` |
+
+### Adding a token
+
+1. Add the field to [`GeistTheme`](../../packages/design_system/lib/src/theme/src/geist_theme.dart) (or the relevant `ThemeExtension`) with both `light` and `dark` values.
+2. Update `copyWith` and `lerp`.
+3. Consume in `lib/` via `context.geist.newToken` — never inline the hex.
+
+The only "bare" colors permitted in `lib/` are `Colors.transparent` and the result of `Color.lerp` applied to tokens already sourced from the DS.
+
+### Dark mode
+
+Both `lightTheme` and `darkTheme` register `GeistTheme` (see [`light_theme.dart`](../../packages/design_system/lib/src/theme/src/light_theme.dart)). Follow [DESIGN.md](../../DESIGN.md) — desaturated tonal variants, not pure inversion. Every foreground/background pair must meet WCAG AA (4.5:1 body, 3:1 large/UI) in **both** modes.
+
+### Consequences
+
+- Good: visual consistency by construction; new screens cannot drift from the system.
+- Good: dark mode is a property of the token, not the consumer.
+- Good: a designer changing a token cascades to every site automatically.
+- Bad: prototyping a new color requires editing the DS package first.
+- Bad: developers must know the token catalog — adding the wrong token name silently picks a similar-looking but semantically different token.
+
+## Pros and Cons of the Options
+
+### DS tokens only
+- Good: enforced consistency; auditable dark mode.
+- Bad: friction for prototypes.
+
+### Tokens + escape hatches
+- Good: ergonomic for one-offs.
+- Bad: "one-off" decays — escape hatches accumulate, dark mode regresses.
+
+### Per-feature mini-themes
+- Good: feature autonomy.
+- Bad: cross-feature inconsistency; brand drift; designer tooling fragments.
+
+## Links
+
+- [ADR-0014 Melos package split](0014-melos-package-split.md)
+- Code: [packages/design_system](../../packages/design_system), [DESIGN.md](../../DESIGN.md)

--- a/docs/adr/0014-melos-package-split.md
+++ b/docs/adr/0014-melos-package-split.md
@@ -1,0 +1,81 @@
+# 14. Melos Package Split: `api` and `design_system`
+
+- Status: Accepted
+- Date: 2026-05-08
+- Deciders: Flutter team
+
+## Context and Problem Statement
+
+Two parts of the codebase have a different change cadence and audience from feature code: the HTTP client + DTOs, and the design system. Keeping them inside `lib/` mixes their codegen with feature-level codegen, makes it hard to share them with future apps, and clutters feature trees with `models/` and `theme/` peers.
+
+We need a packaging strategy that isolates these concerns without forcing a multi-repo setup.
+
+## Decision Drivers
+
+- Reuse — `packages/api` and `packages/design_system` are candidates for sharing across apps.
+- Build hygiene — codegen scoped to the package that needs it, not the whole app.
+- Single repo — one `git`/PR/CI for everything; no submodules.
+
+## Considered Options
+
+- **Melos workspace + Dart `workspace:` + two packages (`api`, `design_system`)**.
+- **Single package — everything under `lib/`**.
+- **Separate repos for `api` and `design_system`, consumed via git refs or pub.dev**.
+
+## Decision Outcome
+
+Chosen option: **Melos workspace + Dart `workspace:`**.
+
+Top-level [`pubspec.yaml`](../../pubspec.yaml) declares:
+
+```yaml
+workspace:
+  - packages/api
+  - packages/design_system
+```
+
+…which makes `dart pub` resolve all three packages together, and registers `melos` (`^7.5.1`) for multi-package script orchestration. Melos scripts (defined in the same `pubspec.yaml`) drive package-aware operations:
+
+| Script | Purpose |
+|---|---|
+| `melos run bootstrap` (custom) | Get deps + generate code for every package — runs `melos run deps && melos run generate` |
+| `melos run build` | `dart run build_runner build -d` across `api`, `design_system`, app |
+| `melos run analyze` / `test` / `format` / `lint` | Per-package code quality |
+| `melos run translations` | Run `easy_localization:generate` against `assets/translations/en-US.json` |
+| `melos exec --scope api -- "..."` | Run an arbitrary command inside one package |
+
+> **Naming note:** `melos bootstrap` (without `run`) is the Melos built-in that runs `pub get` across the workspace. The custom `bootstrap:` script defined in `pubspec.yaml` is invoked as `melos run bootstrap` and additionally runs codegen. Use `melos run bootstrap` when you want both deps + codegen; the bare `melos bootstrap` only fetches deps.
+
+### Package responsibilities
+
+- **`packages/api`** — HTTP boundary. `@RestApi()` Retrofit providers + `@freezed` DTOs. Has no Flutter dependency on widgets. See [ADR-0011](0011-retrofit-typed-api-layer.md).
+- **`packages/design_system`** — visual language. `GeistTheme`, components (`PrimaryButton`, etc.), generated `Assets`, asset codegen via `flutter_gen`. See [ADR-0013](0013-design-system-tokens-only.md).
+- **`lib/`** (the app) — features, navigation, DI bootstrap, app-level services (`DioService`, interceptors), localization wiring.
+
+### Consequences
+
+- Good: codegen runs only where it changes. Editing a DTO recompiles `api`, not the design system.
+- Good: `packages/*` can be lifted into another app with no rewrite — they have no dependency on `lib/`.
+- Good: Dart workspace gives a single `pub get` resolution; no version drift between packages.
+- Bad: three `pubspec.yaml` files instead of one — adding a dependency requires choosing the right package.
+- Bad: `melos` is an extra tool contributors must install (`dart pub global activate melos` or via the workspace dev_dependency).
+
+## Pros and Cons of the Options
+
+### Melos workspace + Dart `workspace:`
+- Good: clean isolation, single repo, shared lockfile.
+- Bad: extra `pubspec.yaml` files; melos learning curve.
+
+### Single package
+- Good: simplest pubspec.
+- Bad: codegen and tests run for the whole app every time; no path to reuse `api` / `design_system` in another app.
+
+### Separate repos
+- Good: maximal isolation; independent versioning.
+- Bad: cross-cutting changes need three PRs; submodule / pub-private setup adds CI complexity.
+
+## Links
+
+- [ADR-0011 Retrofit + freezed typed API layer](0011-retrofit-typed-api-layer.md)
+- [ADR-0013 Design-system tokens only](0013-design-system-tokens-only.md)
+- Code: [pubspec.yaml](../../pubspec.yaml), [packages/api](../../packages/api), [packages/design_system](../../packages/design_system)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,31 @@
+# Architecture Decision Records
+
+ADRs codify the **why** behind architectural rules in this repo. CLAUDE.md and `.cursor/rules/*.mdc` carry the day-to-day conventions and how-to material; this directory is the source of truth for decisions that had real alternatives.
+
+Format: [MADR 3.0](https://adr.github.io/madr/). Status `Accepted` means the rule describes how the codebase already works.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-layered-architecture.md) | Layered architecture with adjacent-only access | Accepted |
+| [0002](0002-state-vs-store-separation.md) | State vs Store separation | Accepted |
+| [0003](0003-no-use-case-to-use-case-dependencies.md) | Use cases never depend on other use cases | Accepted |
+| [0004](0004-use-case-taxonomy-and-colocation.md) | Use case taxonomy and colocation by consumer | Accepted |
+| [0005](0005-flat-feature-tree.md) | Flat feature tree (no nested `features/`) | Accepted |
+| [0006](0006-feature-owned-singletons.md) | Feature-owned singletons (no `lib/shared/`) | Accepted |
+| [0007](0007-di-scopes-and-constructor-injection.md) | DI scopes and constructor injection | Accepted |
+| [0008](0008-appnavigator-routing-abstraction.md) | `AppNavigator` routing abstraction | Accepted |
+| [0009](0009-provider-based-state-access.md) | Provider-based state access in widgets | Accepted |
+| [0010](0010-hookwidget-default.md) | `HookWidget` as the default stateful widget | Accepted |
+| [0011](0011-retrofit-typed-api-layer.md) | Retrofit + freezed typed API layer | Accepted |
+| [0012](0012-mandatory-localization.md) | Mandatory localization (no hardcoded UI strings) | Accepted |
+| [0013](0013-design-system-tokens-only.md) | Design-system tokens only in `lib/` | Accepted |
+| [0014](0014-melos-package-split.md) | Melos package split: `api` and `design_system` | Accepted |
+
+## Adding a new ADR
+
+1. Copy `0000-template.md` to `NNNN-kebab-slug.md`.
+2. Fill in MADR fields. List at least 2 alternatives with concrete trade-offs.
+3. Add a row above.
+4. If the decision changes a rule referenced from CLAUDE.md, update the CLAUDE.md "Architectural decisions" section.


### PR DESCRIPTION
## Summary

Migrate architectural rules from CLAUDE.md prose into 14 formal Architecture Decision Records (MADR 3.0) under `docs/adr/`. ADRs become the source of truth for *why*; CLAUDE.md remains the day-to-day reference and how-to.

All ADRs marked `status: Accepted` — they describe how the codebase already works.

## ADRs added

| # | Title |
|---|---|
| 0001 | Layered architecture with adjacent-only access |
| 0002 | State vs Store separation |
| 0003 | Use cases never depend on other use cases |
| 0004 | Use case taxonomy and colocation by consumer |
| 0005 | Flat feature tree (no nested `features/`) |
| 0006 | Feature-owned singletons (no `lib/shared/`) |
| 0007 | DI scopes and constructor injection |
| 0008 | `AppNavigator` routing abstraction |
| 0009 | Provider-based state access in widgets |
| 0010 | `HookWidget` as the default stateful widget |
| 0011 | Retrofit + freezed typed API layer |
| 0012 | Mandatory localization |
| 0013 | Design-system tokens only in `lib/` |
| 0014 | Melos package split: `api` and `design_system` |

Plus `docs/adr/README.md` (index) and `docs/adr/0000-template.md`.

## Doc updates

- **CLAUDE.md** — new "Architectural decisions" section with one-liner + ADR link per rule. Verbose rule bodies collapse to summary + ADR pointer; convention/operational sections (commands, naming, code-quality workflow, testing, quick navigation) untouched.
- **DESIGN.md** — body unchanged (visual reference). 2-line pointer added at top → ADR-0013 (DS tokens) and ADR-0014 (package split).
- **`.cursor/rules/*`** — untouched.

## Doc fixes surfaced during migration

- CLAUDE.md API Layer section described a `BaseResponseDto<T>` envelope that does not exist in the codebase. Updated to the actual pattern: typed Retrofit returning DTOs directly, with `ListResponseDto<T>` for paginated lists.
- CLAUDE.md `melos bootstrap` command corrected to `melos run bootstrap` — the bare `melos bootstrap` is the Melos built-in that only fetches deps, not the custom script that also runs codegen.

## Phase-3 review notes baked in

`flutter-expert` agent verified ADRs against real source. Adjustments applied:
- ADR-0006 — clarify that `ConnectionWrapperState` row is not a singleton (it shares the `mobx/` directory with stores but is `@injectable`).
- ADR-0007 — add `@lazySingleton` as the third scope (used by `DioService`); CLAUDE.md DI summary updated to match.
- ADR-0011 — note shared DTOs at `packages/api/lib/src/models/`; flag the `ListResponseDto implements Exception` oddity as a follow-up cleanup, not a pattern to propagate.
- ADR-0014 — call out the `melos bootstrap` (built-in) vs `melos run bootstrap` (custom script) naming collision.

## Test plan

- [ ] `docs/adr/README.md` lists all 14 ADRs with working links
- [ ] CLAUDE.md "Architectural decisions" section links resolve
- [ ] DESIGN.md ADR pointer renders correctly
- [ ] Each ADR's "Links" section cross-references resolve (no 404s)
- [ ] No code changes — repo behavior unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Architecture Decision Record (ADR) system documenting key architectural patterns and decisions.
  * Updated project conventions with clarified rules for state management, dependency injection, routing, and feature organization.
  * Formalized design-system token requirements and deprecated legacy shared structures.
  * Enhanced developer guidance on localization, API layer design, and widget patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->